### PR TITLE
Add support for custom rosters

### DIFF
--- a/server/api/user/rosteroperative.py
+++ b/server/api/user/rosteroperative.py
@@ -1,0 +1,120 @@
+import uuid
+from typing import List
+
+from db.schema import (
+    Equipment,
+    Operative,
+    Roster,
+    RosterOperative,
+    User,
+    Weapon,
+    WeaponProfile,
+)
+from models.rosteroperative import AddRosterOperative
+from sqlmodel import select
+
+
+class RosterOperativeAPI:
+
+    # rosterid: str
+    # baseopid: str
+    # opname: str
+    # factionid: str
+    # killteamid: str
+    # fireteamid: str
+    # opid: str
+    # wepids: str
+    # eqids: str
+    @staticmethod
+    def create_roster_operative(
+        roster_id: str, roster_operative_args: AddRosterOperative, user: User, session
+    ):
+        # Create a new roster operative
+        query = (
+            select(Roster)
+            .where(Roster.userid == user.userid)
+            .where(Roster.rosterid == roster_id)
+        )
+        roster_row = session.exec(query).first()
+        if roster_row is None:
+            return None
+
+        query = select(Operative, Weapon, Equipment).where(
+            Operative.factionid == roster_row.factionid,
+            Operative.killteamid == roster_row.killteamid,
+            Operative.opid == roster_operative_args.baseopid,
+            Weapon.factionid == roster_row.factionid,
+            Weapon.killteamid == roster_row.killteamid,
+            Weapon.opid == roster_operative_args.baseopid,
+            WeaponProfile.factionid == roster_row.factionid,
+            WeaponProfile.killteamid == roster_row.killteamid,
+            WeaponProfile.opid == roster_operative_args.baseopid,
+            Equipment.factionid == roster_row.factionid,
+            Equipment.killteamid == roster_row.killteamid,
+        )
+        rows = session.exec(query).fetchall()
+
+        if rows is None or len(rows) == 0:
+            return None
+
+        base_operative = rows[0][0]
+        weapons = {row[1].wepid: row[1] for row in rows[0:]}
+        equipment = {row[2].eqid: row[2] for row in rows[0:]}
+
+        new_roster_operative = RosterOperative(
+            userid=user.userid,
+            rosterid=roster_id,
+            rosteropid=uuid.uuid4(),
+            factionid=roster_row.factionid,
+            killteamid=roster_row.killteamid,
+            fireteamid=base_operative.fireteamid,
+            opid=base_operative.opid,
+            opname=roster_operative_args.opname,
+            wepids=roster_operative_args.wepids,
+            eqids=roster_operative_args.eqids,
+        )
+        if not RosterOperativeAPI._validate_roster_operative(
+            roster_row, new_roster_operative, base_operative, weapons, equipment
+        ):
+            return None
+        session.add(new_roster_operative)
+        session.commit()
+        session.refresh(new_roster_operative)
+        return new_roster_operative
+
+    @staticmethod
+    def _validate_roster_operative(
+        current_roster: Roster,
+        new_roster_operative: RosterOperative,
+        base_operative: Operative,
+        weapons: List[Weapon] = None,
+        equipment: List[Equipment] = None,
+    ):
+        # Ensure the csv weapids and eqids are valid
+        weapon_ids = new_roster_operative.wepids.split(",")
+        equipment_ids = new_roster_operative.eqids.split(",")
+
+        if len(weapon_ids) > 0:
+            for weapon_id in weapon_ids:
+                if weapon_id not in weapons:
+                    return False
+        else:
+            return False
+
+        if len(equipment_ids) > 0:
+            for equipment_id in equipment_ids:
+                if equipment_id not in equipment or (
+                    equipment[equipment_id].opid != ""
+                    and equipment[equipment_id].opid != base_operative.opid
+                ):
+                    return False
+
+        # Ensure new operative does not exceed the fireteam maximum
+        if base_operative.fireteammax > 0:
+            current_count = 0
+            for roster_op in current_roster.operatives:
+                if roster_op.opid == base_operative.opid:
+                    current_count += 1
+            if current_count == base_operative.fireteammax:
+                return False
+        return True

--- a/server/api/user/user.py
+++ b/server/api/user/user.py
@@ -47,7 +47,7 @@ class User:
         return user
 
 
-def get_current_user(
+def get_current_user_with_session(
     session: SessionDep, token: Annotated[str, Depends(oauth2_scheme)]
 ):
     credentials_exception = HTTPException(

--- a/server/models/roster.py
+++ b/server/models/roster.py
@@ -1,14 +1,34 @@
-from pydantic import BaseModel
-from typing import List
 from datetime import datetime
+from typing import List
 
 from models.rosteroperative import RosterOperative
+from pydantic import BaseModel
 
 
 class CreateRoster(BaseModel):
     rostername: str
     factionid: str
     killteamid: str
+
+
+class GetRosters(BaseModel):
+    count: int
+    showcase: bool
+    factionid: str
+    killteamid: str
+
+
+class RosterShort(BaseModel):
+    rosterid: str
+    rostername: str
+    userid: str
+    portrait: str
+    notes: str | None
+    factionid: str | None
+    killteamid: str | None
+    viewcount: int
+    importcount: int
+    showcase: bool
 
 
 class Roster(BaseModel):

--- a/server/models/rosteroperative.py
+++ b/server/models/rosteroperative.py
@@ -1,9 +1,30 @@
-from pydantic import BaseModel
 from typing import List
 
+from models.equipment import Equipment
 from models.operative import Operative
 from models.weapon import Weapon
-from models.equipment import Equipment
+from pydantic import BaseModel
+
+
+class AddRosterOperative(BaseModel):
+    baseopid: str
+    opname: str
+    factionid: str
+    killteamid: str
+    fireteamid: str
+    wepids: str
+    eqids: str
+
+
+class RosterOperativeShort(BaseModel):
+    rosteropid: str
+    opname: str
+
+    baseoperative: Operative
+    wepids: str
+    eqids: str
+
+    specialism: str
 
 
 class RosterOperative(BaseModel):

--- a/server/routes/roster_operatives.py
+++ b/server/routes/roster_operatives.py
@@ -1,22 +1,42 @@
-from routes.rosters import rosters_router
+from typing import Annotated
+
+from api.user.rosteroperative import RosterOperativeAPI
+from api.user.user import get_current_user_with_session
 from db.engine import SessionDep
+from fastapi import Depends, APIRouter
+from models.rosteroperative import AddRosterOperative
+from models.user import User
+
+roster_op_router = APIRouter(prefix="/api/roster_operatives")
 
 
-@rosters_router.post("/{roster_id}/operatives")
-def add_roster_operative(roster_id: str, session: SessionDep):
+@roster_op_router.post("/{roster_id}/operatives")
+def add_roster_operative(
+    roster_id: str,
+    roster_operative_args: AddRosterOperative,
+    current_user: Annotated[User, Depends(get_current_user_with_session)],
+):
+    """
+    Test path: /api/rosters/862286e7-0464-46bc-99e1-3b8b270b82b0/operatives
+    Test body:
+    {
+        "baseopid": "GNR",
+        "opname": "testop",
+        "factionid": "IMP",
+        "killteamid": "GK",
+        "fireteamid": "GK",
+        "wepids": "F,INC,PSC,PSL",
+        "eqids": "PS,TSA"
+    }
+    """
     # Add a new operative to the roster
-
-    # Implement your logic here to add a new operative to the roster
-    pass
-
-
-@rosters_router.get("/{roster_id}/operatives/{opertative_id}")
-def get_roster_operative(roster_id: str, operative_id: str, session: SessionDep):
-    # Return the operative with the given ID in the roster
-    pass
+    new_operative = RosterOperativeAPI.create_roster_operative(
+        roster_id, roster_operative_args, current_user[0], current_user[1]
+    )
+    return new_operative
 
 
-@rosters_router.put("/{roster_id}/operatives/{opertative_id}")
+@roster_op_router.put("/{roster_id}/operatives/{opertative_id}")
 def update_roster_operative(roster_id: str, operative_id: str, session: SessionDep):
     # Update the operative with the given ID in the roster
 
@@ -24,7 +44,7 @@ def update_roster_operative(roster_id: str, operative_id: str, session: SessionD
     pass
 
 
-@rosters_router.delete("/{roster_id}/operatives/{opertative_id}")
+@roster_op_router.delete("/{roster_id}/operatives/{opertative_id}")
 def delete_roster_operative(roster_id: str, operative_id: str, session: SessionDep):
     # Delete the operative with the given ID from the roster
     pass

--- a/server/routes/rosters.py
+++ b/server/routes/rosters.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends
 from db.engine import SessionDep
 from models.user import User
 from models.roster import CreateRoster
-from api.user.user import get_current_user
+from api.user.user import get_current_user_with_session
 from api.user.roster import RosterAPI
 
 rosters_router = APIRouter(prefix="/api/rosters")
@@ -18,16 +18,19 @@ def get_rosters(session: SessionDep):
 @rosters_router.post("/")
 def create_roster(
     roster: CreateRoster,
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(get_current_user_with_session)],
 ):
     # Create a new roster
     return RosterAPI.create_roster(roster, current_user[0], current_user[1])
 
 
 @rosters_router.get("/{roster_id}")
-def get_roster(roster_id: str, session: SessionDep):
+def get_roster(
+    roster_id: str,
+    session: SessionDep,
+):
     # Return the roster with the given ID
-    pass
+    return RosterAPI.get_roster(roster_id, session)
 
 
 @rosters_router.put("/{roster_id}")

--- a/server/run.py
+++ b/server/run.py
@@ -9,6 +9,7 @@ from models.settings import SETTINGS
 from routes.authentication import authentication_router
 from routes.killteams import killteams_router
 from routes.rosters import rosters_router
+from routes.roster_operatives import roster_op_router
 from routes.user import user_router
 
 app = FastAPI()
@@ -18,6 +19,7 @@ app.include_router(base_router)
 app.include_router(authentication_router)
 app.include_router(killteams_router)
 app.include_router(rosters_router)
+app.include_router(roster_op_router)
 app.include_router(user_router)
 
 


### PR DESCRIPTION
**Purpose:**
This implementation was made to allow for user-specific rosters to be created.

**Tasks:** 
- [ ] Returning an abbreviated list of rosters by faction/killteam to display to users 
- [ ] Creating a custom roster (requires faction, killteam, and name)
- [ ] Adding operatives to the their roster
- [ ] Making changes to the roster name, image, or description
- [ ] Modifying already added operatives within the roster
- [ ] Deleting rosters
- [ ] Deleting Operatives
- [ ] Selecting Tac-Ops for the roster
- [ ] Accept game-state changes for rosters and operatives(Tracking of Turning point, Command Points, etc.)
- [ ] Uploading images for the operatives
- [ ] A user uploading an image for their roster

**Database Schema Changes:**
- n/a

**Testing:**
- (Upcoming)

**Description:**
- (Upcoming)